### PR TITLE
Temp fix for crash on wayland

### DIFF
--- a/io.github.milkshiift.GoofCord.yml
+++ b/io.github.milkshiift.GoofCord.yml
@@ -12,11 +12,11 @@ separate-locales: false
 
 finish-args:
   - --socket=pulseaudio
-  - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --share=network
   - --share=ipc
   - --talk-name=org.kde.StatusNotifierWatcher # Tray functionalities on KDE
+  - --talk-name=com.canonical.Unity # For setBadgeCount to work
   - --device=all # Needed for GPU acceleration and the webcam
   - --filesystem=xdg-videos:ro
   - --filesystem=xdg-pictures:ro

--- a/startgoofcord
+++ b/startgoofcord
@@ -1,35 +1,14 @@
 #!/usr/bin/env bash
 
-FEATURES="UseSkiaRenderer,VaapiVideoDecoder,VaapiVideoEncoder,PulseaudioLoopbackForScreenShare,VaapiVideoDecodeLinuxGL,WaylandWindowDecorations"
 export TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-io.github.milkshiift.GoofCord}"
-# https://wiki.archlinux.org/title/Chromium
-declare -a FLAGS=(
-  --enable-gpu-rasterization     # To support mixed refresh rates + hardware acceleration
-  --ignore-gpu-blocklist         # Forcing hardware acceleration
-  --enable-zero-copy             # Hardware acceleration
-  --enable-drdc                  # Hardware acceleration
-)
 
-if [[ $XDG_SESSION_TYPE == "wayland" ]]; then
-    if [[ -c /dev/nvidia0 ]]; then
-        echo "Using NVIDIA on Wayland, disabling gpu sandbox"
-        FLAGS+=(--disable-gpu-sandbox)
-    fi
+declare -a FLAGS=()
 
-    WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
-    if [[ "${WAYLAND_SOCKET:0:1}" != "/" ]]; then
-        WAYLAND_SOCKET="$XDG_RUNTIME_DIR/$WAYLAND_SOCKET"
-    fi
-
-    if [[ -e "$WAYLAND_SOCKET" ]]; then
-        echo "Wayland socket is available, running natively on Wayland."
-        echo "To disable, remove the --socket=wayland permission."
-        FLAGS+=(--ozone-platform-hint=auto)
-        FLAGS+=(--enable-wayland-ime)
-        FLAGS+=(--wayland-text-input-version=3)
-    fi
+if [[ $XDG_SESSION_TYPE == "wayland" && -z "$DISPLAY" ]]; then
+    echo "Using Wayland"
+    FLAGS+=(--enable-wayland-ime)
+    FLAGS+=(--wayland-text-input-version=3)
 fi
 
-FLAGS+=(--enable-features="${FEATURES}")
 echo "Passing the following arguments to Electron:" "${FLAGS[@]}"
 exec zypak-wrapper /app/bin/goofcord/goofcord "${FLAGS[@]}" "$@"


### PR DESCRIPTION
Disables the wayland socket by default.
Also cleans up the start script.