### PR TITLE
Make PipeWire socket read-only

### DIFF
--- a/io.github.milkshiift.GoofCord.yml
+++ b/io.github.milkshiift.GoofCord.yml
@@ -22,7 +22,7 @@ finish-args:
   - --filesystem=xdg-videos:ro
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-download # This and the above two are used for drag-n-drop, and download managing
-  - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing for Venmic
+  - --filesystem=xdg-run/pipewire-0:ro # Pipewire interfacing for Venmic
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons:/usr/share/icons # This is used to show the correct cursor on Wayland
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.kwalletd5


### PR DESCRIPTION
Flatpaks should not have write access to socket files, like `xdg-run/pipewire-0`. Bidirectional communication is possible regardless of the suffix, so a benevolent app sees no difference. While it shouldn't be possible in theory, it would be best to prevent the possibility of deleting or modifying the socket itself. Flathub maintainers typically request this for new submissions.

https://discourse.flathub.org/t/what-is-the-difference-if-the-pipewire-socket-is-read-only/11951/7